### PR TITLE
Replace argsort with argpartition, simplify rand calls

### DIFF
--- a/src/fairdo/optimize/baseline.py
+++ b/src/fairdo/optimize/baseline.py
@@ -44,10 +44,10 @@ def random_method(f, d, pop_size=100, num_generations=500):
     np.array, float
         The final solution vector and its fitness value.
     """
-    best_solution = np.random.randint(0, 2, size=d)
+    best_solution = np.random.randint(2, size=d)
     best_fitness = f(best_solution)
     for _ in range(pop_size * num_generations):
-        new_solution = np.random.randint(0, 2, size=d)
+        new_solution = np.random.randint(2, size=d)
         new_fitness = f(new_solution)
         if new_fitness < best_fitness:
             best_solution = new_solution
@@ -80,7 +80,7 @@ def random_method_vectorized(f, d, pop_size=100, num_generations=500):
     np.array, float
         The final solution vector and its fitness value.
     """
-    solutions = np.random.randint(0, 2, size=(pop_size * num_generations, d))
+    solutions = np.random.randint(2, size=(pop_size * num_generations, d))
     fitness_values = np.apply_along_axis(f, 1, solutions)
 
     best_index = np.argmin(fitness_values)

--- a/src/fairdo/optimize/geneticoperators/mutation.py
+++ b/src/fairdo/optimize/geneticoperators/mutation.py
@@ -37,7 +37,7 @@ def fractional_flip_mutation(offspring, mutation_rate=0.05):
     num_mutation = int(mutation_rate * offspring.shape[1])
     for idx in range(offspring.shape[0]):
         # select the random bits to flip
-        mutation_bits = np.random.choice(np.arange(offspring.shape[1]),
+        mutation_bits = np.random.choice(offspring.shape[1],
                                          num_mutation,
                                          replace=False)
         # flip the bits
@@ -83,7 +83,7 @@ def swap_mutation(offspring):
     """
     for idx in range(offspring.shape[0]):
         # select two random bits
-        bit1, bit2 = np.random.choice(np.arange(offspring.shape[1]), 2, replace=False)
+        bit1, bit2 = np.random.choice(offspring.shape[1], 2, replace=False)
         # swap the bits
         offspring[idx, bit1], offspring[idx, bit2] = offspring[idx, bit2], offspring[idx, bit1]
     return offspring
@@ -134,30 +134,30 @@ def diverse_mutation(offspring, mutation_rate=0.05):
     """
     # Calculate the proportion of 1s in each offspring
     proportion_ones = np.mean(offspring, axis=1)
-    
+
     # Adjust the mutation rate based on the proportion of 1s
     mutated_proportion_ones = proportion_ones + np.random.uniform(-0.1, 0.1, size=proportion_ones.shape)
     mutated_proportion_ones = np.clip(mutated_proportion_ones, 0, 1)  # Ensure values are within [0, 1] range
-    
+
     # Generate mutated offspring
     mutation_probs = mutation_rate * mutated_proportion_ones
     mutated_mask = np.random.rand(*offspring.shape) < mutation_probs[:, np.newaxis]
     mutated_offspring = np.where(mutated_mask, 1 - offspring, offspring)
-    
+
     return mutated_offspring
 
 
 def shuffle_mutation(offspring, **kwargs):
     """
     Mutates the given offspring by shuffling the bits of each offspring.
-    
+
     Parameters
     ----------
     offspring: ndarray, shape (n, d)
         The offspring to be mutated. Each row represents an offspring, and each column represents a bit.
     kwargs: dict
         Additional keyword arguments. Ignored.
-    
+
     Returns
     -------
     offspring: ndarray, shape (n, d)

--- a/src/fairdo/optimize/geneticoperators/selection.py
+++ b/src/fairdo/optimize/geneticoperators/selection.py
@@ -42,7 +42,7 @@ def elitist_selection(population, fitness, num_parents=2):
     fitness: ndarray, shape (num_parents,)
     """
     # select the best individuals from the population to be parents
-    idx = np.argsort(fitness)
+    idx = np.argpartition(fitness, -num_parents)[-num_parents:]
     parents = population[idx[-num_parents:]]
     parents_fitness = fitness[idx[-num_parents:]]
     return parents, parents_fitness
@@ -80,7 +80,7 @@ def tournament_selection(population, fitness, num_parents=2, tournament_size=3):
     parents = np.empty((num_parents, population.shape[1]))
     parents_fitness = np.empty(num_parents)
     for i in range(num_parents):
-        tournament_indices = np.random.randint(0, len(population), size=tournament_size)
+        tournament_indices = np.random.randint(len(population), size=tournament_size)
         tournament_fitnesses = fitness[tournament_indices]
         winner_index = tournament_indices[np.argmax(tournament_fitnesses)]
         parents[i, :] = population[winner_index, :]
@@ -128,7 +128,7 @@ def roulette_wheel_selection(population, fitness, num_parents=2):
         fitness = fitness - 2*np.min(fitness)
     fitness_sum = np.sum(fitness)
     selection_probs = fitness / fitness_sum
-    parents_idx = np.random.choice(np.arange(len(population)), size=num_parents, p=selection_probs)
+    parents_idx = np.random.choice(len(population), size=num_parents, p=selection_probs)
     return population[parents_idx], fitness[parents_idx]
 
 
@@ -179,7 +179,7 @@ def stochastic_universal_sampling(population, fitness, num_parents=2):
     distance = 1.0 / num_parents
 
     # Initialize the start of the pointers
-    start = np.random.uniform(0, distance)
+    start = np.random.uniform(distance)
 
     # Initialize the parents
     parents = np.empty((num_parents, population.shape[1]))
@@ -229,7 +229,7 @@ def rank_selection(population, fitness, num_parents=2):
     selection_probabilities = ranks / total_ranks
 
     # Select parents based on selection probabilities
-    parent_indices = np.random.choice(np.arange(len(population)), size=num_parents, p=selection_probabilities)
+    parent_indices = np.random.choice(len(population), size=num_parents, p=selection_probabilities)
 
     parents = population[parent_indices]
     fitness = fitness[parent_indices]

--- a/src/fairdo/optimize/multi.py
+++ b/src/fairdo/optimize/multi.py
@@ -302,8 +302,8 @@ def selection_indices(combined_fitness_values, fronts, pop_size):
             # If the current front cannot fit entirely, select individuals based on crowding distance
             crowding_distances = crowding_distance(combined_fitness_values[current_front])
             # Select individuals with larger crowding distances first
-            sorted_indices = np.argsort(crowding_distances)[::-1]
-            selected_indices.extend(current_front[sorted_indices[:remaining_space]])
+            indices = np.argpartition(crowding_distances, -remaining_space)[-remaining_space:]
+            selected_indices.extend(current_front[indices])
             remaining_space = 0
         front_idx += 1
 


### PR DESCRIPTION
If we want to select the $k$ largest values from an array of size $n$, we can do so in $O(n + k)$ using https://en.wikipedia.org/wiki/Introselect

This is usually faster than the current `np.argsort`, which runs in $O(n \log n)$. Empirically, the `elitist_selection` is roughly 10 times faster now, but it does not have a large effect on the overall running time of the algorithm, which is dominated by other functions.

Note that the order of the $k$ largest values may be arbitrary. I did not find any non-interactive tests, but the example from the README still returns the same results after the changes (after adding `np.random.seed(0)`). Nevertheless, someone should probably double-check if order is important for the `elitist_selection` and `selection_indices` functions.

While I was at it, I also simplified some calls to random functions.